### PR TITLE
Added ability to tweak .gitattributes

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,6 +9,7 @@ the default configuration with the following parameters:
 * `tags` - fetches tags when set to `true`
 * `submodule_override` - override submodule urls
 * `submodule_update_remote` - pass the `--remote` flag to git submodule update (useful when tracking a branch instead of a commit in a submodule)
+* `tweak_gitattributes` - tweaks .gitttributes to ensure that no filters will be applied, there will be no `$Id$` substitution, and line endings will be forced to LF
 
 Sample configuration:
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Clone a commit
 ```sh
 ./drone-git <<EOF
 {
-	"repo": {
-		"clone": "git://github.com/drone/drone"
-	},
-	"build": {
-		"event": "push",
-		"branch": "master",
-		"commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
-		"ref": "refs/heads/master"
-	},
-	"workspace": {
-		"root": "/drone/src",
-		"path": "/drone/src/github.com/drone/drone",
-	}
+    "repo": {
+	"clone": "git://github.com/drone/drone"
+    },
+    "build": {
+	"event": "push",
+	"branch": "master",
+	"commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
+	"ref": "refs/heads/master"
+    },
+    "workspace": {
+	"root": "/drone/src",
+	"path": "/drone/src/github.com/drone/drone",
+    }
 }
 EOF
 ```
@@ -34,19 +34,19 @@ Clone a pull request
 ```sh
 ./drone-git <<EOF
 {
-	"repo": {
-		"clone": "git://github.com/drone/drone"
-	},
-	"build": {
-		"event": "pull_request",
-		"branch": "master",
-		"commit": "8d6a233744a5dcacbf2605d4592a4bfe8b37320d",
-		"ref": "refs/pull/892/merge"
-	},
-	"workspace": {
-		"root": "/drone/src",
-		"path": "/drone/src/github.com/drone/drone",
-	}
+    "repo": {
+	"clone": "git://github.com/drone/drone"
+    },
+    "build": {
+	"event": "pull_request",
+	"branch": "master",
+	"commit": "8d6a233744a5dcacbf2605d4592a4bfe8b37320d",
+	"ref": "refs/pull/892/merge"
+    },
+    "workspace": {
+	"root": "/drone/src",
+	"path": "/drone/src/github.com/drone/drone",
+    }
 }
 EOF
 ```
@@ -56,31 +56,47 @@ Clone a tag
 ```sh
 ./drone-git <<EOF
 {
-	"repo": {
-		"clone": "git://github.com/drone/drone"
-	},
-	"build": {
-		"event": "tag",
-		"branch": "master",
-		"commit": "339fb92b9629f63c0e88016fffb865e3e1055483",
-		"ref": "refs/tags/v0.2.0"
-	},
-	"workspace": {
-		"root": "/drone/src",
-		"path": "/drone/src/github.com/drone/drone",
-	}
+    "repo": {
+	"clone": "git://github.com/drone/drone"
+    },
+    "build": {
+	"event": "tag",
+	"branch": "master",
+	"commit": "339fb92b9629f63c0e88016fffb865e3e1055483",
+	"ref": "refs/tags/v0.2.0"
+    },
+    "workspace": {
+	"root": "/drone/src",
+	"path": "/drone/src/github.com/drone/drone",
+    }
 }
 EOF
 ```
 
+## Build instructions
+
+This code relies on unmerged pull request drone/drone-plugin-go#4 so there are some preparations steps required:
+
+You need to fetch locally pull request drone/drone-plugin-go#4 using the following commands
+
+```sh
+cd $GOPATH/src/github.com/drone/drone-plugin-go
+git fetch origin pull/4/head:pull-4
+git checkout pull-4
+```
+
+Then you may be able to build `drone-git` usual way
+
 ## Docker
+
+Building Docker container requires the same preparation steps as a regular build does.
 
 Build the Docker container using the `netgo` build tag to eliminate
 the CGO dependency:
 
 ```sh
 CGO_ENABLED=0 go build -a -tags netgo
-docker build --rm=true -t plugins/drone-git .
+docker build --rm=true -t sourcegraph/drone-git .
 ```
 
 Clone a repository inside the Docker container:
@@ -88,19 +104,19 @@ Clone a repository inside the Docker container:
 ```sh
 docker run -i plugins/drone-git <<EOF
 {
-	"repo": {
-		"clone": "git://github.com/drone/drone"
-	},
-	"build": {
-		"event": "push",
-		"branch": "master",
-		"commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
-		"ref": "refs/heads/master"
-	},
-	"workspace": {
-		"root": "/drone/src",
-		"path": "/drone/src/github.com/drone/drone",
-	}
+    "repo": {
+	"clone": "git://github.com/drone/drone"
+    },
+    "build": {
+	"event": "push",
+	"branch": "master",
+	"commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
+	"ref": "refs/heads/master"
+    },
+    "workspace": {
+	"root": "/drone/src",
+	"path": "/drone/src/github.com/drone/drone",
+    }
 }
 EOF
 ```

--- a/main.go
+++ b/main.go
@@ -308,7 +308,7 @@ type tweak struct {
 }
 
 // .gitattribute tweaking rules
-var tweaks = make([]tweak, 0, 3)
+var tweaks [3]tweak
 
 // initializes .gitattribute tweaking rules
 // current rules are:
@@ -320,17 +320,17 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	tweaks = append(tweaks, tweak{p, "eol=lf"})
+	tweaks[0] = tweak{p, "eol=lf"}
 	p, err = regexp.Compile(`([^=]|^)ident\b`)
 	if err != nil {
 		panic(err)
 	}
-	tweaks = append(tweaks, tweak{p, ""})
+	tweaks[1] = tweak{p, ""}
 	p, err = regexp.Compile(`\bfilter=(\S+)`)
 	if err != nil {
 		panic(err)
 	}
-	tweaks = append(tweaks, tweak{p, ""})
+	tweaks[2] = tweak{p, ""}
 }
 
 // tweakGitattributes tweaks .gitattributes in the given directory

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,7 @@ import (
 	"github.com/drone/drone-plugin-go/plugin"
 )
 
-var netrcFile = `
+var netrcEntry = `
 machine %s
 login %s
 password %s
@@ -219,22 +220,26 @@ func trace(cmd *exec.Cmd) {
 
 // Writes the netrc file.
 func writeNetrc(in *plugin.Workspace) error {
-	if in.Netrc == nil || len(in.Netrc.Machine) == 0 {
+	if len(in.Netrc) == 0 {
 		return nil
 	}
-	out := fmt.Sprintf(
-		netrcFile,
-		in.Netrc.Machine,
-		in.Netrc.Login,
-		in.Netrc.Password,
-	)
+	var out bytes.Buffer
+	for _, e := range in.Netrc {
+		fmt.Fprintf(
+			&out,
+			netrcEntry,
+			e.Machine,
+			e.Login,
+			e.Password,
+		)
+	}
 	home := "/root"
 	u, err := user.Current()
 	if err == nil {
 		home = u.HomeDir
 	}
 	path := filepath.Join(home, ".netrc")
-	return ioutil.WriteFile(path, []byte(out), 0600)
+	return ioutil.WriteFile(path, out.Bytes(), 0600)
 }
 
 // Writes the RSA private key

--- a/main_test.go
+++ b/main_test.go
@@ -379,7 +379,7 @@ func TestUpdateSubmodulesRemote(t *testing.T) {
 // helper function that will setup a temporary workspace.
 // to which we can clone the repositroy
 func setup() string {
-	dir, _ := ioutil.TempDir("/tmp", "drone_git_test_")
+	dir, _ := ioutil.TempDir("", "drone_git_test_")
 	os.Mkdir(dir, 0777)
 	return dir
 }

--- a/main_test.go
+++ b/main_test.go
@@ -195,9 +195,22 @@ func TestClone(t *testing.T) {
 			t.Errorf("Expected successful clone. Got error. %s.", err)
 		}
 
-		data := readFile(dir, c.file)
-		if data != c.data {
-			t.Errorf("Expected %s to contain [%s]. Got [%s].", c.file, c.data, data)
+		fileData := readFile(dir, c.file)
+		if fileData != c.data {
+			t.Errorf("Expected %s to contain [%s]. Got [%s].", c.file, c.data, fileData)
+		}
+
+		if c.tweak {
+			cmd := exec.Command("git", "show", c.commit+":"+c.file)
+			cmd.Dir = dir
+			data, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Error(err)
+			}
+			gitData := string(data)
+			if gitData != fileData {
+				t.Errorf("Expected file %s to contain raw data [%s]. Got [%s].", c.file, gitData, fileData)
+			}
 		}
 
 		if c.tags != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -15,16 +16,18 @@ import (
 // commits is a list of commits of different types (push, pull request, tag)
 // to help us verify that this clone plugin can handle multiple commit types.
 var commits = []struct {
-	path       string
-	clone      string
-	event      string
-	branch     string
-	commit     string
-	ref        string
-	file       string
-	data       string
-	tags       []string
-	submodules map[string]string
+	path             string
+	clone            string
+	event            string
+	branch           string
+	commit           string
+	ref              string
+	file             string
+	data             string
+	tags             []string
+	submodules       map[string]string
+	tweak            bool
+	skipNotEmptyTest bool
 }{
 	// first commit
 	{
@@ -118,6 +121,49 @@ var commits = []struct {
 			"Hello-World": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 		},
 	},
+	// tweak attributes (eol=crlf)
+	{
+		path:       "sgtest/gitattributes",
+		clone:      "https://github.com/sgtest/gitattributes.git",
+		event:      plugin.EventPush,
+		branch:     "master",
+		commit:     "4d003e20c18ce15a69eeac67b3fdb94932d35271",
+		ref:        "refs/heads/master",
+		file:       "crlf.go",
+		data:       "package main\n\nfunc bar() {\n\tbar()\n}",
+		tags:       nil,
+		submodules: nil,
+		tweak:      true,
+	},
+	// tweak attributes (ident)
+	{
+		path:       "sgtest/gitattributes",
+		clone:      "https://github.com/sgtest/gitattributes.git",
+		event:      plugin.EventPush,
+		branch:     "master",
+		commit:     "4d003e20c18ce15a69eeac67b3fdb94932d35271",
+		ref:        "refs/heads/master",
+		file:       "ident.go",
+		data:       "package main\n\nvar qux = \"$Id$\"",
+		tags:       nil,
+		submodules: nil,
+		tweak:      true,
+	},
+	// tweak attributes (disabled)
+	{
+		path:       "sgtest/gitattributes",
+		clone:      "https://github.com/sgtest/gitattributes.git",
+		event:      plugin.EventPush,
+		branch:     "master",
+		commit:     "4d003e20c18ce15a69eeac67b3fdb94932d35271",
+		ref:        "refs/heads/master",
+		file:       "ident.go",
+		data:       "package main\r\n\r\nvar qux = \"$Id: b1a36a842cd537057c6214ba858fe16654cc0935 $\"",
+		tags:       nil,
+		submodules: nil,
+		// you can't change "TweakGitattributes" while checking in into the same directory
+		skipNotEmptyTest: true,
+	},
 }
 
 // TestClone tests the ability to clone a specific commit into
@@ -141,8 +187,9 @@ func TestClone(t *testing.T) {
 		b := &plugin.Build{Commit: c.commit, Branch: c.branch, Ref: c.ref, Event: c.event}
 		w := &plugin.Workspace{Path: dir}
 		v := &Params{
-			Recursive: recursive,
-			Tags:      tags,
+			Recursive:          recursive,
+			Tags:               tags,
+			TweakGitattributes: c.tweak,
 		}
 		if err := clone(r, b, w, v); err != nil {
 			t.Errorf("Expected successful clone. Got error. %s.", err)
@@ -190,6 +237,10 @@ func TestCloneNonEmpty(t *testing.T) {
 
 	for _, c := range commits {
 
+		if c.skipNotEmptyTest {
+			continue
+		}
+
 		recursive := false
 		if c.submodules != nil {
 			recursive = true
@@ -204,8 +255,9 @@ func TestCloneNonEmpty(t *testing.T) {
 		b := &plugin.Build{Commit: c.commit, Branch: c.branch, Ref: c.ref, Event: c.event}
 		w := &plugin.Workspace{Path: filepath.Join(dir, c.path)}
 		v := &Params{
-			Recursive: recursive,
-			Tags:      tags,
+			Recursive:          recursive,
+			Tags:               tags,
+			TweakGitattributes: c.tweak,
 		}
 		if err := clone(r, b, w, v); err != nil {
 			t.Errorf("Expected successful clone. Got error. %s.", err)
@@ -386,6 +438,9 @@ func setup() string {
 
 // helper function to delete the temporary workspace.
 func teardown(dir string) {
+	if runtime.GOOS == "windows" {
+		clearReadOnly(dir)
+	}
 	os.RemoveAll(dir)
 }
 
@@ -445,4 +500,35 @@ func getSubmodules(dir string) (map[string]string, error) {
 		return nil, err
 	}
 	return submodules, nil
+}
+
+// Tries to remove READONLY mark from file (recursive)
+// On Windows, os.Remove does not work if file was marked as READONLY (for example, git does it)
+func clearReadOnly(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !fi.IsDir() {
+		return os.Chmod(path, 0666)
+	}
+
+	fd, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	names, _ := fd.Readdirnames(-1)
+	for _, name := range names {
+		err = clearReadOnly(filepath.Join(path, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- Added new parameter - `tweak_gitattributes` that enables tweaking of `.gitattributes` at checkout to disable all features modifying content (eol=crlf, indent, filter=NAME). The reason is that we need to be consistent when fetching file's content from Git blob using `git show COMMIT:NAME` and when file's content retrieved as a result of `git clone` is passed to toolchain for indexing
- On Windows trying to clear R/O file attributes before recursively removing test data at the teardown test phase, otherwise `os.RemoveAll` fails leaving orphan files
- Contains all the changes from sqs/drone-git@multiple-netrc-entries
- Fixed unit tests on Windows
- Added special build instructions because current source code relies on unmerged pull request
