### PR TITLE
Sometimes we need to commit temporary changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,9 @@
 
 FROM alpine:3.2
 RUN apk add -U ca-certificates git openssh curl perl && rm -rf /var/cache/apk/*
+# The following two lines required because sometimes we 
+# performing "git commit" (for example, to tweak line endings in .gitattributes)
+RUN git config --global user.email "drone-git@sourcegraph.com" 
+RUN git config --global user.name "drone-git"
 ADD drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]


### PR DESCRIPTION
- set `user.name` and `user.email` to make `git commit` happy. This is required for cases when we need to commit temporary changes, for example when we are tweaking `.gitattributes` to adjust line endings
